### PR TITLE
fix:fix bug about pos in function tofp64

### DIFF
--- a/fp64.c
+++ b/fp64.c
@@ -517,7 +517,7 @@ static int64_t tofp64(lua_State* L, int pos)
             }
             break;
         case LUA_TSTRING:
-            n = _parse_str(L, n);
+            n = _parse_str(L, pos);
             break;
 #ifdef USELIGHTUSERDATA
         case LUA_TLIGHTUSERDATA:


### PR DESCRIPTION
Fix bug about pos in function tofp64, change ‘n’ to ‘pos’.